### PR TITLE
Add openocd support in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,10 @@
   "containerEnv" : {
     "USER": "builder"
   },
+  "mounts": [
+    "type=bind,source=/dev/bus/usb,target=/dev/bus/usb"
+  ],
+  "runArgs": ["--privileged"],
   "features": {
   }
 }

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -16,8 +16,16 @@ RUN \
  RUN \
     sudo apt-get update -qq \
     && DEBIAN_FRONTEND=noninteractive sudo apt-get -y install --no-install-recommends \
-        wget mc tree less bzip2 zip \
+        wget mc tree less bzip2 zip usbutils libtool pkg-config libusb-1.0-0-dev unzip autotools-dev automake\
     && sudo apt-get autoclean && sudo apt-get clean && sudo apt-get -y autoremove
+
+
+# Install openocd
+RUN cd && mkdir flash && cd flash && \
+        git clone https://github.com/meriac/openocd && \
+        cd openocd && \
+        ./bootstrap && ./configure --enable-ch347 --disable-werror && \
+        make -j $(nproc) && sudo make install
 
 # install configuration files like for mc
 COPY --chown=${USER} .config /home/${USER}/.config

--- a/examples/colorlight_i9plus/README.md
+++ b/examples/colorlight_i9plus/README.md
@@ -18,40 +18,9 @@
 
 [<img src="../../documentation/images/i9plus-extboard.jpg">](https://github.com/wuxx/Colorlight-FPGA-Projects/blob/master/colorlight_i9plus_v6.1.md)
 
-
-## Build OpenOCD for programming ColorLight i9+ using CH347 on Linux
-
-[OpenOCD](https://openocd.org/), a versatile tool providing on-chip
-programming and debugging support, can be used for programming the
-ColorLight i9+ platform, particularly with the [CH347 chip](https://www.wch-ic.com/products/CH347.html). This guide will
-take you through the steps to build and configure OpenOCD for this
-specific use case.
-
-To set up OpenOCD for the CH347 chip on the ColorLight i9+ platform, follow these steps:
-```shell
-# Clone the OpenOCD repository
-git clone https://github.com/meriac/openocd
-
-# Navigate to the cloned repository
-cd openocd
-
-# Initialize the build configuration
-./bootstrap 
-
-# Configure the build specifically for CH347, while disabling warnings as errors
-./configure --enable-ch347 --disable-werror
-
-# Compile the source code using multiple threads for faster build
-make -j
-
-# Install OpenOCD to the system
-sudo make install
-```
-Ensure you have all necessary dependencies installed before proceeding with the build. For any issues or detailed documentation, refer to the [OpenOCD GitHub repository](https://github.com/meriac/openocd) or the [official OpenOCD documentation](https://openocd.org/pages/documentation.html).
-
 ### Programming ColorLight i9+ using CH347 on Linux using OpenOCD
 
-After installing OpenOCD in the previous step, you can use the following commands for programming ColorLight i9+ modules: 
+OpenOCD in already installed in devcontainer, you can use the following commands for programming ColorLight i9+ modules with sudo:
 - `ch347prog-sram`: For temporarily programming a bitstream file during development.
 - `ch347prog-flash`: For permanently programming a bitstream file.
 - `ch347prog-probe`: For detecting the device and the connected flash memory.


### PR DESCRIPTION
In order to make it flash from inside devcontainer, adding support for openocd compiled for CH347.